### PR TITLE
Initialize YuihaFS.

### DIFF
--- a/fs/ext3/file.c
+++ b/fs/ext3/file.c
@@ -51,6 +51,13 @@ static int ext3_release_file (struct inode * inode, struct file * filp)
 	return 0;
 }
 
+static int yuiha_file_open(struct inode * inode, struct file *filp)
+{
+	printk("yuiha_file_open ino=%lu\n", inode->i_ino);
+	int ret = generic_file_open(inode, filp);
+	return ret;
+}
+
 const struct file_operations ext3_file_operations = {
 	.llseek		= generic_file_llseek,
 	.read		= do_sync_read,
@@ -63,6 +70,24 @@ const struct file_operations ext3_file_operations = {
 #endif
 	.mmap		= generic_file_mmap,
 	.open		= generic_file_open,
+	.release	= ext3_release_file,
+	.fsync		= ext3_sync_file,
+	.splice_read	= generic_file_splice_read,
+	.splice_write	= generic_file_splice_write,
+};
+
+const struct file_operations yuiha_file_operations = {
+	.llseek		= generic_file_llseek,
+	.read		= do_sync_read,
+	.write		= do_sync_write,
+	.aio_read	= generic_file_aio_read,
+	.aio_write	= generic_file_aio_write,
+	.unlocked_ioctl	= ext3_ioctl,
+#ifdef CONFIG_COMPAT
+	.compat_ioctl	= ext3_compat_ioctl,
+#endif
+	.mmap		= generic_file_mmap,
+	.open		= yuiha_file_open,
 	.release	= ext3_release_file,
 	.fsync		= ext3_sync_file,
 	.splice_read	= generic_file_splice_read,

--- a/fs/ext3/inode.c
+++ b/fs/ext3/inode.c
@@ -40,6 +40,7 @@
 #include <linux/namei.h>
 #include "xattr.h"
 #include "acl.h"
+#include "super.h"
 
 static int ext3_writepage_trans_blocks(struct inode *inode);
 
@@ -2761,6 +2762,7 @@ struct inode *ext3_iget(struct super_block *sb, unsigned long ino)
 	transaction_t *transaction;
 	long ret;
 	int block;
+	struct file_system_type *fs_type = sb->s_type;
 
 	inode = iget_locked(sb, ino);
 	if (!inode)
@@ -2889,8 +2891,11 @@ struct inode *ext3_iget(struct super_block *sb, unsigned long ino)
 		ei->i_extra_isize = 0;
 
 	if (S_ISREG(inode->i_mode)) {
+		if (ext3_judge_yuiha(fs_type))
+			inode->i_fop = &yuiha_file_operations;
+		else
+			inode->i_fop = &ext3_file_operations;
 		inode->i_op = &ext3_file_inode_operations;
-		inode->i_fop = &ext3_file_operations;
 		ext3_set_aops(inode);
 	} else if (S_ISDIR(inode->i_mode)) {
 		inode->i_op = &ext3_dir_inode_operations;

--- a/fs/ext3/super.h
+++ b/fs/ext3/super.h
@@ -1,0 +1,4 @@
+#include <asm/uaccess.h>
+#include <linux/fs.h>
+
+int ext3_judge_yuiha(struct file_system_type *);

--- a/include/linux/ext3_fs.h
+++ b/include/linux/ext3_fs.h
@@ -936,6 +936,7 @@ extern const struct file_operations ext3_dir_operations;
 /* file.c */
 extern const struct inode_operations ext3_file_inode_operations;
 extern const struct file_operations ext3_file_operations;
+extern const struct file_operations yuiha_file_operations;
 
 /* namei.c */
 extern const struct inode_operations ext3_dir_inode_operations;


### PR DESCRIPTION
Define file_system_type structure of Ext3 and YuihaFS separately, so that YuihaFS and Ext3 can coexist.

![image](https://github.com/higuruchi/YuihaFS/assets/64151192/8f51c8bd-c5a6-41b0-adc7-4098fca0a040)
