### PR TITLE
Change interpretation of i_ctime member of version inode.

### DIFF
--- a/fs/ext3/inode.c
+++ b/fs/ext3/inode.c
@@ -3376,9 +3376,6 @@ struct inode *ext3_iget(struct super_block *sb, unsigned long ino)
 					le32_to_cpu(yuiha_raw_inode->i_child_generation);
 
 			yi->i_vtree_nlink = le16_to_cpu(yuiha_raw_inode->i_vtree_nlink);
-
-			yi->i_vtime.tv_sec = (signed)le32_to_cpu(yuiha_raw_inode->i_vtime);
-			yi->i_vtime.tv_nsec = 0;
 		} else {
 			inode->i_fop = &ext3_file_operations;
 		}
@@ -3554,8 +3551,6 @@ again:
 		yuiha_raw_inode->i_child_generation = cpu_to_le32(yi->i_child_generation);
 
 		yuiha_raw_inode->i_vtree_nlink = cpu_to_le16(yi->i_vtree_nlink);
-
-		yuiha_raw_inode->i_vtime = cpu_to_le32(yi->i_vtime.tv_sec);
 	}
 
 	BUFFER_TRACE(bh, "call ext3_journal_dirty_metadata");
@@ -3706,42 +3701,6 @@ err_out:
 	if (!error)
 		error = rc;
 	return error;
-}
-
-void yuiha_getattr(struct file *filp, struct kstat *stat,
-		struct timespec *vtime)
-{
-	struct inode *inode = filp->f_dentry->d_inode;
-	struct yuiha_inode_info *yi = YUIHA_I(inode);
-
-	generic_fillattr(inode, stat);
-	*vtime = yi->i_vtime;
-
-	return;
-}
-
-int cp_yuiha_stat(struct kstat *stat, struct timespec *vtime,
-		struct yuiha_stat __user *ystat_buf)
-{
-	struct yuiha_stat tmp;
-
-	memset(&tmp, 0, sizeof(struct yuiha_stat));
-	tmp.st_dev = old_encode_dev(stat->dev);
-	tmp.st_ino = stat->ino;
-	if (sizeof(tmp.st_ino) < sizeof(stat->ino) && tmp.st_ino != stat->ino)
-		return -EOVERFLOW;
-	tmp.st_mode = stat->mode;
-	tmp.st_nlink = stat->nlink;
-	if (tmp.st_nlink != stat->nlink)
-		return -EOVERFLOW;
-	SET_UID(tmp.st_uid, stat->uid);
-	SET_GID(tmp.st_gid, stat->gid);
-	tmp.st_size = stat->size;
-	tmp.st_atime = stat->atime.tv_sec;
-	tmp.st_mtime = stat->mtime.tv_sec;
-	tmp.st_ctime = stat->ctime.tv_sec;
-	tmp.st_vtime = vtime->tv_sec;
-	return copy_to_user(ystat_buf, &tmp, sizeof(tmp)) ? -EFAULT : 0;
 }
 
 /*

--- a/fs/ext3/ioctl.c
+++ b/fs/ext3/ioctl.c
@@ -302,13 +302,6 @@ group_add_out:
 	case YUIHA_IOC_LINK_VERSION: {
 		return yuiha_vlink(filp, (char __user *) arg);
 	}
-	case YUIHA_IOC_STAT_VERSION: {
-		struct kstat stat;
-		struct timespec vtime;
-
-		yuiha_getattr(filp, &stat, &vtime);
-		return cp_yuiha_stat(&stat, &vtime, (struct yuiha_stat __user *) arg);
-	}
 
 	default:
 		return -ENOTTY;

--- a/fs/ext3/namei.c
+++ b/fs/ext3/namei.c
@@ -2138,7 +2138,6 @@ static int yuiha_copy_inode_info(
 	dst_ext3_ei->i_disksize = src_ext3_ei->i_disksize;
 	dst_ext3_ei->i_extra_isize = src_ext3_ei->i_extra_isize;
 	dst_yi->i_vtree_nlink = src_yi->i_vtree_nlink;
-	dst_yi->i_vtime = CURRENT_TIME_SEC;
 
 	dst_inode->i_mode = src_inode->i_mode;
 	dst_inode->i_uid = src_inode->i_uid;
@@ -2147,7 +2146,7 @@ static int yuiha_copy_inode_info(
 	dst_inode->i_size = src_inode->i_size;
 	dst_inode->i_atime = src_inode->i_atime;
 	dst_inode->i_mtime = src_inode->i_mtime;
-	dst_inode->i_ctime = src_inode->i_ctime;
+	dst_inode->i_ctime = CURRENT_TIME_SEC;
 	dst_inode->i_nlink = src_inode->i_nlink;
 	dst_inode->i_blkbits = src_inode->i_blkbits;
 	dst_inode->i_version = src_inode->i_version;

--- a/fs/ext3/yuiha.h
+++ b/fs/ext3/yuiha.h
@@ -9,12 +9,6 @@ extern struct inode *yuiha_ilookup(struct super_block *sb, unsigned long ino);
 extern int yuiha_detach_version(handle_t *handle, struct inode *inode);
 extern int yuiha_vlink(struct file *filp, const char __user *newname);
 
-// fs/ext3/inode.c
-extern int cp_yuiha_stat(struct kstat *stat, struct timespec *vtime,
-		struct yuiha_stat __user *ystat_buf);
-extern void yuiha_getattr(struct file *filp, struct kstat *stat,
-		struct timespec *vtime);
-
 // fs/ext3/yuiha_buffer_head.c
 #define PRODUCER_BITS 31
 

--- a/include/linux/ext3_fs.h
+++ b/include/linux/ext3_fs.h
@@ -254,22 +254,6 @@ struct ext3_new_group_data {
 #define EXT3_IOC_SETRSVSZ		_IOW('f', 6, long)
 #define YUIHA_IOC_DEL_VERSION		_IOWR('f', 9, unsigned long)
 #define YUIHA_IOC_LINK_VERSION	_IOW('f', 10, char __user *)
-#define YUIHA_IOC_STAT_VERSION	_IOR('f', 11, char __user *)
-
-struct yuiha_stat {
-	unsigned short st_dev;
-	unsigned short st_ino;
-	unsigned short st_mode;
-	unsigned short st_nlink;
-	unsigned short st_uid;
-	unsigned short st_gid;
-	unsigned short st_rdev;
-	unsigned long  st_size;
-	unsigned long  st_atime;
-	unsigned long  st_mtime;
-	unsigned long  st_ctime;
-	unsigned long  st_vtime;
-};
 
 /*
  * ioctl commands in 32 bit emulation
@@ -378,7 +362,6 @@ struct yuiha_inode {
 	__le32 i_child_ino;
 	__le32 i_child_generation;
 
-	__le32 i_vtime;
 	// This member only used at root version
 	__le16 i_vtree_nlink;
 };

--- a/include/linux/ext3_fs_i.h
+++ b/include/linux/ext3_fs_i.h
@@ -165,7 +165,6 @@ struct yuiha_inode_info {
 
 	__u16 i_vtree_nlink;
 
-	struct timespec i_vtime;
 	struct inode *parent_inode;
 };
 


### PR DESCRIPTION
i_ctime of version inode is interpreted as version creation time, which is not interpreted as file creation time.

![image](https://github.com/user-attachments/assets/5a83ada2-405b-4feb-9975-71fd0a7138d9)
